### PR TITLE
feat: add classRegex config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ List of languages to apply highlighting.
 ]
 ```
 
+### `tailwindcss-highlight.classRegex`
+
+Regex used to detect class attributes/functions that contain tailwind classes to be highlighted.
+
+```json
+"tailwindcss-highlight.classRegex": [
+  "(?:\\b(?:class(?:Name)?|tw)\\s*=\\s*(?:(?:{([^>}]+)})|([\"'`][^\"'`]+[\"'`])))",
+  "(?:(clsx|classnames))\\(([^)(]*(?:\\([^)(]*(?:\\([^)(]*(?:\\([^)(]*\\)[^)(]*)*\\)[^)(]*)*\\)[^)(]*)*)\\)"
+]
+```
+
 ### `tailwindcss-highlight.enabledUtilities`
 
 List of utilities to highlight.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,18 @@
             "type": "string"
           }
         },
+        "tailwindcss-highlight.classRegex": {
+          "default": [
+            "(?:\\b(?:class(?:Name)?|tw)\\s*=\\s*(?:(?:{([^>}]+)})|([\"'`][^\"'`]+[\"'`])))",
+            "(?:(clsx|classnames))\\(([^)(]*(?:\\([^)(]*(?:\\([^)(]*(?:\\([^)(]*\\)[^)(]*)*\\)[^)(]*)*\\)[^)(]*)*)\\)"
+          ],
+          "title": "ClassRegex",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Regex used to detect classes to highlight."
+        },
         "tailwindcss-highlight.defaultVariantsColor": {
           "default": "#1FAB89",
           "title": "DefaultVariantsColor",

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -33,6 +33,10 @@ export interface MyConfiguration {
    * Configure a list of languages that should be highlight.
    */
   languages: string[]
+  /**
+   * Configure the regex used to detect classes to highlight.
+   */
+  classRegex: string[]
 }
 
 export class Configuration {
@@ -44,6 +48,14 @@ export class Configuration {
 
   get languages(): MyConfiguration['languages'] {
     return this.configuration.get('languages') ?? []
+  }
+
+  get classRegex(): MyConfiguration['classRegex'] {
+    // FIXME: 正規表現だけでは様々なケースに対応できない
+    return this.configuration.get('classRegex') ?? [
+      '(?:\\b(?:class(?:Name)?|tw)\\s*=\\s*(?:(?:{([^>}]+)})|(["\'`][^"\'`]+["\'`])))',
+      '(?:(clsx|classnames))\\(([^)(]*(?:\\([^)(]*(?:\\([^)(]*(?:\\([^)(]*\\)[^)(]*)*\\)[^)(]*)*\\)[^)(]*)*)\\)'
+    ]
   }
 
   get configs(): MyConfiguration['configs'] {

--- a/src/utils/decoration.ts
+++ b/src/utils/decoration.ts
@@ -40,7 +40,7 @@ export class Decoration {
     if (editor == null) return
     const document = editor.document
     const text = document.getText()
-    const classNames = getClassNames(text)
+    const classNames = getClassNames(text, this.configuration.classRegex)
     this.decorators.forEach((decorator) => {
       const regex = new RegExp(decorator.regex, 'g')
       const chars: DecorationOptions[] = []

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,13 +1,10 @@
 export function getClassNames(
-  targetText: string
+  targetText: string,
+  classRegex: string[]
 ): Array<{ start: number; value: string }> {
   const arr = []
   // FIXME: 正規表現だけでは様々なケースに対応できない
-  const regexes = [
-    /(?:\b(?:class(?:Name)?|tw)\s*=\s*(?:(?:{([^>}]+)})|(["'`][^"'`]+["'`])))/,
-    /(?:(clsx|classnames)\()([^)]+)\)/
-  ]
-  const regex = new RegExp(regexes.map((r) => r.source).join('|'), 'gm')
+  const regex = new RegExp(classRegex.join('|'), 'gm')
   const classNameMatches = targetText.matchAll(regex)
   for (const classNameMatch of classNameMatches) {
     const stringMatches = classNameMatch[0].matchAll(


### PR DESCRIPTION
Adds a new `classRegex` configuration property that allows users to change the regex used to detect class attributes (e.g. `class="..."`, `className="..."`, etc.) / functions (e.g. `clsx`, `classnames`, etc.).

Additionally modifies the 'function' regex to fix an issue where highlighting breaks after a closing bracket is encountered inside a class name. The regex used is based on another discussion of a similar issue found here: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/868